### PR TITLE
feat: enable teacache and first block cache(FBcache)

### DIFF
--- a/docker/Dockerfile.bd_iaas
+++ b/docker/Dockerfile.bd_iaas
@@ -64,6 +64,17 @@ RUN mkdir /app && \
     git checkout ${WAN_BRANCH} && \
     pip install -r requirements.txt -i ${BYTED_PIP_INDEX}
 
+RUN cd /app && \
+    git clone https://github.com/bytedance-iaas/xDiT.git && \
+    cd xDiT && \
+    git checkout release_0.0.4
+
+RUN cd /app && \
+    git clone https://github.com/bytedance-iaas/diffusers.git && \
+    cd diffusers && \
+    git checkout iaas_main && \
+    pip install -e ".[torch]"
+
 RUN pip install torch==2.7.0 torch-utils packaging torchvision torch_tensorrt yunchang==0.6.3.post1 && \
     pip uninstall -y opencv-python
 

--- a/examples/run_wan2_cfg_usp.sh
+++ b/examples/run_wan2_cfg_usp.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -x
+
+export PYTHONPATH=$PWD:$PYTHONPATH
+
+# Wan2.1 configuration
+SCRIPT="wan2_cfg_usp_example.py"
+MODEL_ID="/data00/models/Wan2.1-T2V-14B-Diffusers/"
+INFERENCE_STEP=50
+
+mkdir -p ./results
+
+# Wan2.1 specific task args
+TASK_ARGS="--height 720 --width 1280 --num_frames 81 --seed 0 --enable_fa3 --use_torch_compile --use_fbcache --cache_threshold 0.16"
+N_GPUS=8
+PARALLEL_ARGS="--ulysses_degree 4 --ring_degree 1"
+CFG_ARGS="--use_cfg_parallel"
+
+# Uncomment and modify these as needed
+# PIPEFUSION_ARGS="--num_pipeline_patch 8"
+# OUTPUT_ARGS="--output_type latent"
+# PARALLLEL_VAE="--use_parallel_vae"
+# ENABLE_TILING="--enable_tiling"
+# COMPILE_FLAG="--use_torch_compile"
+
+torchrun --nproc_per_node=$N_GPUS ./examples/$SCRIPT \
+--model $MODEL_ID \
+$PARALLEL_ARGS \
+$TASK_ARGS \
+$PIPEFUSION_ARGS \
+$OUTPUT_ARGS \
+--num_inference_steps $INFERENCE_STEP \
+--warmup_steps 0 \
+--prompt "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage." \
+$CFG_ARGS \
+$PARALLLEL_VAE \
+$ENABLE_TILING \
+$COMPILE_FLAG  \
+--negative_prompt "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人 很多，倒着走"

--- a/examples/wan2_cfg_usp_example.py
+++ b/examples/wan2_cfg_usp_example.py
@@ -1,0 +1,298 @@
+import os
+os.environ['NCCL_DEBUG'] = 'ERROR'
+import sys
+import functools
+from typing import List, Optional, Tuple, Union, Dict, Any
+import torch.distributed as dist
+
+import logging
+import time
+import torch
+import torch.distributed
+from diffusers import AutoModel, DiffusionPipeline, AutoencoderKLWan
+from diffusers.schedulers.scheduling_unipc_multistep import UniPCMultistepScheduler
+from xfuser import xFuserArgs, xFuserWanPipeline
+from xfuser.config import FlexibleArgumentParser
+from xfuser.core.distributed import (
+    get_world_group,
+    get_data_parallel_rank,
+    get_data_parallel_world_size,
+    get_sequence_parallel_world_size,
+    get_sequence_parallel_rank,
+    get_runtime_state,
+    is_dp_last_group,
+    init_distributed_environment,
+    initialize_model_parallel,
+    get_world_group,
+    get_sp_group,
+    get_classifier_free_guidance_world_size,
+    get_classifier_free_guidance_rank,
+    get_cfg_group,
+    initialize_runtime_state,
+    get_pipeline_parallel_world_size,
+)
+from diffusers.utils import export_to_video
+from diffusers.utils import scale_lora_layers, unscale_lora_layers, USE_PEFT_BACKEND
+from diffusers.models.attention import Attention
+from diffusers.models.transformers.transformer_wan import WanAttnProcessor2_0
+from xfuser.core.long_ctx_attention import xFuserLongContextAttention
+from transformers import UMT5EncoderModel
+
+from xfuser.model_executor.layers.attention_processor import xFuserWanAttnProcessor2_0
+from xfuser.model_executor.cache.diffusers_adapters.wan import apply_cache_on_pipe
+from xfuser.logger import init_logger
+logger = init_logger(__name__)
+
+def parallelize_transformer(pipe: DiffusionPipeline):
+    transformer = pipe.transformer
+    original_forward = transformer.forward
+
+    @functools.wraps(transformer.__class__.forward)
+    def new_forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_image: Optional[torch.Tensor] = None,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        return_dict: bool = True,
+    ) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
+        if attention_kwargs is not None:
+            attention_kwargs = attention_kwargs.copy()
+            lora_scale = attention_kwargs.pop("scale", 1.0)
+        else:
+            lora_scale = 1.0
+
+        if USE_PEFT_BACKEND:
+            # weight the lora layers by setting `lora_scale` for each PEFT layer
+            scale_lora_layers(self, lora_scale)
+        else:
+            if attention_kwargs is not None and attention_kwargs.get("scale", None) is not None:
+                logger.warning(
+                    "Passing `scale` via `attention_kwargs` when not using the PEFT backend is ineffective."
+                )
+
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.config.patch_size
+        post_patch_num_frames = num_frames // p_t  
+        post_patch_height = height // p_h          
+        post_patch_width = width // p_w     
+
+        rotary_emb = self.rope(hidden_states)
+        
+        hidden_states = self.patch_embedding(hidden_states)
+        hidden_states = hidden_states.flatten(2).transpose(1, 2)
+
+        #split timestep hidden_states
+        timestep = torch.chunk(timestep, get_classifier_free_guidance_world_size(),dim=0)[get_classifier_free_guidance_rank()]
+        hidden_states = torch.chunk(hidden_states,
+                                    get_classifier_free_guidance_world_size(),
+                                    dim=0)[get_classifier_free_guidance_rank()]
+        hidden_states = torch.chunk(hidden_states, get_sequence_parallel_world_size(), dim=-2)[get_sequence_parallel_rank()]
+
+
+        temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image = self.condition_embedder(
+            timestep, encoder_hidden_states, encoder_hidden_states_image
+        )
+        timestep_proj = timestep_proj.unflatten(1, (6, -1))
+
+        if encoder_hidden_states_image is not None:
+            encoder_hidden_states = torch.concat([encoder_hidden_states_image, encoder_hidden_states], dim=1)
+
+        if encoder_hidden_states.shape[-2] % get_sequence_parallel_world_size() != 0:
+            split_text_embed_in_sp = False
+        else:
+            split_text_embed_in_sp = True
+        encoder_hidden_states = torch.chunk(encoder_hidden_states,get_classifier_free_guidance_world_size(),dim=0)[get_classifier_free_guidance_rank()]
+        if split_text_embed_in_sp:
+            encoder_hidden_states = torch.chunk(encoder_hidden_states, get_sequence_parallel_world_size(), dim=-2)[get_sequence_parallel_rank()]
+
+        freqs_cos, freqs_sin = rotary_emb
+        def get_rotary_emb_chunk(freqs):
+            freqs = torch.chunk(freqs, get_sequence_parallel_world_size(), dim=2)[get_sequence_parallel_rank()]
+            return freqs
+        freqs_cos = get_rotary_emb_chunk(freqs_cos)
+        freqs_sin = get_rotary_emb_chunk(freqs_sin)
+        rotary_emb = (freqs_cos, freqs_sin)
+
+        #4. Transformer blocks
+        if torch.is_grad_enabled() and self.gradient_checkpointing:
+            for block in self.blocks:
+                    hidden_states = self._gradient_checkpointing_func(
+                        block, hidden_states, encoder_hidden_states, timestep_proj, rotary_emb
+                    )
+        else:
+            for block in self.blocks:
+                hidden_states = block(hidden_states, encoder_hidden_states, timestep_proj, rotary_emb)
+        #5. Output norm, projection & unpatchify
+        shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+
+        # Move the shift and scale tensors to the same device as hidden_states.
+        # When using multi-GPU inference via accelerate these will be on the
+        # first device rather than the last device, which hidden_states ends up
+        # on.
+        shift = shift.to(hidden_states.device)
+        scale = scale.to(hidden_states.device)
+
+        hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(hidden_states)
+        hidden_states = self.proj_out(hidden_states)
+
+        hidden_states = get_sp_group().all_gather(hidden_states, dim=-2)
+        hidden_states = get_cfg_group().all_gather(hidden_states, dim=0)
+
+        hidden_states = hidden_states.reshape(
+            batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1
+        )
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+        if USE_PEFT_BACKEND:
+            # remove `lora_scale` from each PEFT layer
+            unscale_lora_layers(self, lora_scale)
+
+        if not return_dict:
+            return (output,)
+
+        return Transformer2DModelOutput(sample=output)
+
+    new_forward = new_forward.__get__(transformer)
+    transformer.forward = new_forward
+
+    #attn1: self attn  attn2: cross attn
+    for block in transformer.blocks:
+        block.attn1.processor = xFuserWanAttnProcessor2_0()
+        block.attn2.processor = xFuserWanAttnProcessor2_0()
+
+def main():
+    dist.init_process_group("nccl")
+    init_distributed_environment(
+        rank=dist.get_rank(),
+        world_size=dist.get_world_size()
+    )
+
+    parser = FlexibleArgumentParser(description="xFuser Arguments")
+    args = xFuserArgs.add_cli_args(parser).parse_args()
+    engine_args = xFuserArgs.from_cli_args(args)
+    engine_config, input_config = engine_args.create_config()
+    
+    if args.enable_fa3:
+        assert torch.cuda.get_device_capability()[0] >= 9, (
+            "FlashAttention v3 requires SM >= 90. "
+        )
+        import yunchang
+        from yunchang.kernels import AttnType
+        try:
+            import flash_attn_interface
+            FLASH_ATTN_3_AVAILABLE = True
+        except ModuleNotFoundError:
+            FLASH_ATTN_3_AVAILABLE = False
+        assert FLASH_ATTN_3_AVAILABLE == True, ("FlashAttention v3 is not installed")
+
+        setattr(xFuserWanAttnProcessor2_0, "enable_fa3", True)
+    else:
+        setattr(xFuserWanAttnProcessor2_0, "enable_fa3", False)
+    
+    assert engine_args.pipefusion_parallel_degree == 1, "This script does not support PipeFusion."
+    assert engine_args.use_parallel_vae is False, "parallel VAE not implemented for Wan2.1"
+
+    text_encoder = UMT5EncoderModel.from_pretrained(engine_config.model_config.model, subfolder="text_encoder", torch_dtype=torch.bfloat16)
+    vae = AutoencoderKLWan.from_pretrained(engine_config.model_config.model, subfolder="vae", torch_dtype=torch.float32)
+    transformer = AutoModel.from_pretrained(engine_config.model_config.model, subfolder="transformer", torch_dtype=torch.bfloat16)
+
+    pipe = xFuserWanPipeline.from_pretrained(
+        pretrained_model_name_or_path=engine_config.model_config.model,
+        transformer=transformer,
+        vae=vae,
+        text_encoder=text_encoder,
+        engine_config=engine_config,
+        torch_dtype=torch.bfloat16,
+    )
+    flow_shift = 5.0
+    scheduler = UniPCMultistepScheduler(prediction_type='flow_prediction', use_flow_sigmas=True, num_train_timesteps=1000, flow_shift=flow_shift)
+    pipe.scheduler = scheduler
+    local_rank = get_world_group().local_rank
+    device = torch.device(f"cuda:{local_rank}")
+    pipe.to(device)
+
+    initialize_runtime_state(pipe, engine_config)
+
+    if args.enable_sequential_cpu_offload:
+        pipe.enable_sequential_cpu_offload(gpu_id=local_rank)
+        logging.info(f"rank {local_rank} sequential CPU offload enabled")
+    elif args.enable_model_cpu_offload:
+        pipe.enable_model_cpu_offload(gpu_id=local_rank)
+        logging.info(f"rank {local_rank} model CPU offload enabled")
+    else:
+        device = torch.device(f"cuda:{local_rank}")
+        pipe = pipe.to(device)
+
+    if args.enable_tiling:
+        pipe.vae.enable_tiling()
+
+    if args.enable_slicing:
+        pipe.vae.enable_slicing()
+
+    parameter_peak_memory = torch.cuda.max_memory_allocated(device=f"cuda:{local_rank}")
+
+    parallelize_transformer(pipe)
+    if args.use_teacache or args.use_fbcache:
+        if args.use_teacache and args.use_fbcache:
+            logger.warning(f"apply --use_teacache and --use_fbcache togather. we use FBCache")
+            use_cache="Fb"
+        elif args.use_teacache:
+            use_cache="Tea"
+        elif args.use_fbcache:
+            use_cache="Fb"
+        apply_cache_on_pipe(pipe=pipe, use_cache=use_cache, residual_diff_threshold=args.cache_threshold)
+    
+    if engine_config.runtime_config.use_torch_compile:
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        pipe.transformer = torch.compile(pipe.transformer,
+            mode="max-autotune-no-cudagraphs")
+        output = pipe(
+            height=input_config.height,
+            width=input_config.width,
+            num_frames=input_config.num_frames,
+            prompt=input_config.prompt,
+            negative_prompt=input_config.negative_prompt,
+            num_inference_steps=1,
+            guidance_scale=5.0,
+            generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
+        ).frames[0]
+
+    torch.cuda.reset_peak_memory_stats()
+    start_time = time.time()
+    output = pipe(
+        height=input_config.height,
+        width=input_config.width,
+        num_frames=input_config.num_frames,
+        prompt=input_config.prompt,
+        negative_prompt=input_config.negative_prompt,
+        num_inference_steps=input_config.num_inference_steps,
+        guidance_scale=5.0,
+        generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
+    ).frames[0]
+
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+    peak_memory = torch.cuda.max_memory_allocated(device=f"cuda:{local_rank}")
+    parallel_info = (
+        f"dp{engine_args.data_parallel_degree}_cfg{engine_config.parallel_config.cfg_degree}_"
+        f"ulysses{engine_args.ulysses_degree}_ring{engine_args.ring_degree}_"
+        f"tp{engine_args.tensor_parallel_degree}_"
+        f"pp{engine_args.pipefusion_parallel_degree}_patch{engine_args.num_pipeline_patch}"
+    )
+
+    if is_dp_last_group():
+        resolution = f"{input_config.width}x{input_config.height}"
+        output_filename = f"results/wan_{parallel_info}_{resolution}.mp4"
+        export_to_video(output, output_filename, fps=16, quality=8)
+        print(f"output saved to {output_filename}")
+
+    if get_world_group().rank == get_world_group().world_size - 1:
+        print(f"epoch time: {elapsed_time:.2f} sec, parameter memory: {parameter_peak_memory/1e9:.2f} GB, memory: {peak_memory/1e9} GB")
+
+    dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()

--- a/xfuser/__init__.py
+++ b/xfuser/__init__.py
@@ -7,7 +7,8 @@ from xfuser.model_executor.pipelines import (
     xFuserHunyuanDiTPipeline,
     xFuserCogVideoXPipeline,
     xFuserConsisIDPipeline,
-    xFuserStableDiffusionXLPipeline
+    xFuserStableDiffusionXLPipeline,
+    xFuserWanPipeline,
 )
 from xfuser.config import xFuserArgs, EngineConfig
 from xfuser.parallel import xDiTParallel
@@ -22,6 +23,7 @@ __all__ = [
     "xFuserCogVideoXPipeline",
     "xFuserConsisIDPipeline",
     "xFuserStableDiffusionXLPipeline",
+    "xFuserWanPipeline",
     "xFuserArgs",
     "EngineConfig",
     "xDiTParallel",

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -100,10 +100,12 @@ class xFuserArgs:
     no_use_resolution_binning: bool = False
     seed: int = 42
     output_type: str = "pil"
+    guidance_scale: float = 3.5
     enable_model_cpu_offload: bool = False
     enable_sequential_cpu_offload: bool = False
     enable_tiling: bool = False
     enable_slicing: bool = False
+    enable_fa3: bool = False
     # DiTFastAttn arguments
     use_fast_attn: bool = False
     n_calib: int = 8
@@ -113,6 +115,7 @@ class xFuserArgs:
     use_cache: bool = False
     use_teacache: bool = False
     use_fbcache: bool = False
+    cache_threshold : float = 0.12
     use_fp8_t5_encoder: bool = False
 
     @staticmethod
@@ -166,6 +169,10 @@ class xFuserArgs:
             action="store_true",
             help="Enable teacache to accelerate inference in a single card",
         )
+        runtime_group.add_argument(
+            "--cache_threshold", type=float, default=0.12, help="Threshold for cache calculate."
+        )
+
 
         # Parallel arguments
         parallel_group = parser.add_argument_group("Parallel Processing Options")
@@ -290,6 +297,12 @@ class xFuserArgs:
             default="pil",
             help="Output type of the pipeline.",
         )
+        input_group.add_argument(
+            "--guidance_scale",
+            type=float,
+            default=3.5,
+            help="Guidance scale for classifier free guidance.",
+        )
         runtime_group.add_argument(
             "--enable_sequential_cpu_offload",
             action="store_true",
@@ -314,6 +327,11 @@ class xFuserArgs:
             "--use_fp8_t5_encoder",
             action="store_true",
             help="Quantize the T5 text encoder.",
+        )
+        runtime_group.add_argument(
+            "--enable_fa3",
+            action="store_true",
+            help="Enable FlashAttention 3.",
         )
 
         # DiTFastAttn arguments
@@ -437,6 +455,7 @@ class xFuserArgs:
             runtime_config=runtime_config,
             parallel_config=parallel_config,
             fast_attn_config=fast_attn_config,
+            enable_fa3=self.enable_fa3,
         )
 
         input_config = InputConfig(
@@ -452,6 +471,7 @@ class xFuserArgs:
             max_sequence_length=self.max_sequence_length,
             seed=self.seed,
             output_type=self.output_type,
+            guidance_scale=self.guidance_scale,
         )
 
         return engine_config, input_config

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -62,6 +62,7 @@ class RuntimeConfig:
     use_fp8_t5_encoder: bool = False
     use_teacache: bool = False
     use_fbcache: bool = False
+    cache_threshold : float = 0.12
 
     def __post_init__(self):
         check_packages()
@@ -239,10 +240,12 @@ class EngineConfig:
     runtime_config: RuntimeConfig
     parallel_config: ParallelConfig
     fast_attn_config: FastAttnConfig
+    enable_fa3: bool = False
 
     def __post_init__(self):
         if self.fast_attn_config.use_fast_attn:
             assert self.parallel_config.dp_degree == self.parallel_config.dit_parallel_size, f"dit_parallel_size must be equal to dp_degree when using DiTFastAttn"
+
 
     def to_dict(self):
         """Return the configs as a dictionary, for use in **kwargs."""
@@ -263,6 +266,7 @@ class InputConfig:
     max_sequence_length: int = 256
     seed: int = 42
     output_type: str = "pil"
+    guidance_scale: float = 3.5
 
     def __post_init__(self):
         if isinstance(self.prompt, list):

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -118,7 +118,7 @@ class DiTRuntimeState(RuntimeState):
         self.cogvideox = False
         self.consisid = False
         self.hunyuan_video = False
-        if pipeline.__class__.__name__.startswith(("CogVideoX", "ConsisID", "HunyuanVideo")):
+        if pipeline.__class__.__name__.startswith(("CogVideoX", "ConsisID", "HunyuanVideo", "Wan", "xFuserWan")):
             if pipeline.__class__.__name__.startswith("CogVideoX"):
                 self.cogvideox = True
             elif pipeline.__class__.__name__.startswith("ConsisID"):

--- a/xfuser/model_executor/cache/diffusers_adapters/wan.py
+++ b/xfuser/model_executor/cache/diffusers_adapters/wan.py
@@ -1,0 +1,122 @@
+"""
+adapted from https://github.com/ali-vilab/TeaCache.git
+adapted from https://github.com/chengzeyi/ParaAttention.git
+"""
+import functools
+import unittest
+
+import torch
+from torch import nn
+from diffusers import DiffusionPipeline, WanTransformer3DModel
+from xfuser.model_executor.cache.diffusers_adapters.registry import TRANSFORMER_ADAPTER_REGISTRY
+
+from xfuser.model_executor.cache import utils
+
+def create_cached_transformer_blocks(use_cache, transformer):
+    cached_transformer_class = {
+        "Fb": utils.FBCachedWanTransformerBlocks,
+        "Tea": utils.TeaCachedWanTransformerBlocks,
+    }.get(use_cache)
+
+    if not cached_transformer_class:
+        raise ValueError(f"Unsupported use_cache value: {use_cache}")
+    
+    return cached_transformer_class(
+        transformer.blocks,
+        transformer=transformer,
+        return_hidden_states_only=True,
+    )
+
+
+def apply_cache_on_transformer(
+    transformer: WanTransformer3DModel,
+    *,
+    rel_l1_thresh=0.12,
+    return_hidden_states_first=False,
+    num_steps=8,
+    use_cache="Fb",
+    shallow_patch: bool = False,
+    residual_diff_threshold=0.12,
+    downsample_factor=1,
+):
+    if getattr(transformer, "_is_cached", False):
+        return transformer
+    
+    blocks = nn.ModuleList([
+        create_cached_transformer_blocks(
+            use_cache=use_cache, 
+            transformer=transformer,
+        )
+    ])
+    #blocks = torch.nn.ModuleList(
+    #    [
+    #        utils.FBCachedWanTransformerBlocks(
+    #            transformer.blocks,
+    #            transformer=transformer,
+    #            return_hidden_states_only=True,
+    #        )
+    #    ]
+    #)
+
+    #blocks = torch.nn.ModuleList(
+    #    [
+    #        utils.TeaCachedWanTransformerBlocks(
+    #            transformer.blocks,
+    #            transformer=transformer,
+    #            return_hidden_states_only=True,
+    #        )
+    #    ]
+    #)
+
+    original_forward = transformer.forward
+
+    @functools.wraps(transformer.__class__.forward)
+    def new_forward(
+        self,
+        *args,
+        **kwargs,
+    ):
+        with unittest.mock.patch.object(
+            self,
+            "blocks",
+            blocks,
+        ):
+            return original_forward(
+                *args,
+                **kwargs,
+            )
+
+    transformer.forward = new_forward.__get__(transformer)
+    transformer._is_cached = True
+    return transformer
+
+def apply_cache_on_pipe(
+    pipe: DiffusionPipeline,
+    *,
+    shallow_patch: bool = False,
+    residual_diff_threshold=0.12,
+    downsample_factor=1,
+    use_cache="Fb",
+    **kwargs,
+):
+    if not getattr(pipe, "_is_cached", False):
+        original_call = pipe.__class__.__call__
+
+        @functools.wraps(original_call)
+        def new_call(self, *args, **kwargs):
+            num_inference_steps = kwargs.get("num_inference_steps", 50)
+            with utils.cache_context(
+                utils.create_cache_context(
+                    residual_diff_threshold=residual_diff_threshold,
+                    downsample_factor=downsample_factor,
+                    num_inference_steps=num_inference_steps,
+                )
+            ):
+                return original_call(self, *args, **kwargs)
+        pipe.__class__.__call__ = new_call
+        pipe.__class__._is_cached = True
+
+    if not shallow_patch:
+        apply_cache_on_transformer(use_cache=use_cache, transformer=pipe.transformer, **kwargs)
+
+    return pipe

--- a/xfuser/model_executor/cache/utils.py
+++ b/xfuser/model_executor/cache/utils.py
@@ -2,18 +2,19 @@
 adapted from https://github.com/ali-vilab/TeaCache.git
 adapted from https://github.com/chengzeyi/ParaAttention.git
 """
+import contextlib 
 import dataclasses
-from typing import Dict, Optional, List
+from collections import defaultdict
+from typing import Dict, Optional, List, DefaultDict, Union, Any
 from xfuser.core.distributed import (
     get_sp_group,
     get_sequence_parallel_world_size,
 )
-
 import torch
 from torch.nn import Module
 from abc import ABC, abstractmethod
-
-
+from xfuser.logger import init_logger
+logger = init_logger(__name__)
 # --------- CacheContext --------- #
 class CacheContext(Module):
     def __init__(self):
@@ -247,3 +248,398 @@ class TeaCachedTransformerBlocks(CachedTransformerBlocks):
         prev_modulated = self.cache_context.modulated_inputs
         self.cache_context.modulated_inputs = modulated
         return modulated, prev_modulated, hidden_states, encoder_hidden_states
+
+
+
+
+
+@dataclasses.dataclass
+class CacheContext:
+    residual_diff_threshold: Union[torch.Tensor, float] = 0.0
+    downsample_factor: int = 1
+    num_inference_steps: int = -1
+    warmup_steps: int = 0
+    buffers: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    executed_steps: int = 0
+
+    def get_residual_diff_threshold(self):
+        residual_diff_threshold = self.residual_diff_threshold
+        if isinstance(residual_diff_threshold, torch.Tensor):
+            residual_diff_threshold = residual_diff_threshold.item()
+        return residual_diff_threshold
+
+    def get_wan_coef(self):
+        wan_coef = self.wan_coef
+        return wan_coef
+
+    def get_num_inference_steps(self):
+        num_inference_steps = self.num_inference_steps
+        return num_inference_steps
+
+    def get_buffer(self, name):
+        return self.buffers.get(name)
+
+    def set_buffer(self, name, buffer):
+        self.buffers[name] = buffer
+
+    def remove_buffer(self, name):
+        if name in self.buffers:
+            del self.buffers[name]
+
+    def clear_buffers(self):
+        self.buffers.clear()
+
+    def mark_step_begin(self):
+        self.executed_steps += 1
+
+    def get_current_step(self):
+        return self.executed_steps
+
+    def set_current_step(self):
+        self.executed_steps = 0
+
+    def is_in_warmup(self):
+        return self.get_current_step() < self.warmup_steps
+
+@torch.compiler.disable
+def get_residual_diff_threshold():
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    return cache_context.get_residual_diff_threshold()
+
+
+@torch.compiler.disable
+def get_buffer(name):
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    return cache_context.get_buffer(name)
+
+
+@torch.compiler.disable
+def set_buffer(name, buffer):
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    cache_context.set_buffer(name, buffer)
+
+
+@torch.compiler.disable
+def remove_buffer(name):
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    cache_context.remove_buffer(name)
+
+@torch.compiler.disable
+def mark_step_begin():
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    cache_context.mark_step_begin()
+
+@torch.compiler.disable
+def get_current_step():
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    return cache_context.get_current_step()
+
+@torch.compiler.disable
+def set_current_step():
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    cache_context.set_current_step()
+
+@torch.compiler.disable
+def get_num_inference_steps():
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    return cache_context.get_num_inference_steps()
+
+@torch.compiler.disable
+def is_in_warmup():
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    return cache_context.is_in_warmup()
+
+_current_cache_context = None
+
+def create_cache_context(*args, **kwargs):
+    return CacheContext(*args, **kwargs)
+
+def get_current_cache_context():
+    return _current_cache_context
+
+def set_current_cache_context(cache_context=None):
+    global _current_cache_context
+    _current_cache_context = cache_context
+
+@contextlib.contextmanager
+def cache_context(cache_context):
+    global _current_cache_context
+    old_cache_context = _current_cache_context
+    _current_cache_context = cache_context
+    try:
+        yield
+    finally:
+        _current_cache_context = old_cache_context
+
+@torch.compiler.disable
+def apply_prev_hidden_states_residual(hidden_states, encoder_hidden_states):
+    hidden_states_residual = get_hidden_states_residual()
+    assert hidden_states_residual is not None, "hidden_states_residual must be set before"
+    hidden_states = hidden_states_residual + hidden_states
+
+    encoder_hidden_states_residual = get_encoder_hidden_states_residual()
+    assert encoder_hidden_states_residual is not None, "encoder_hidden_states_residual must be set before"
+    encoder_hidden_states = encoder_hidden_states_residual + encoder_hidden_states
+
+    hidden_states = hidden_states.contiguous()
+    encoder_hidden_states = encoder_hidden_states.contiguous()
+
+    return hidden_states, encoder_hidden_states
+
+@torch.compiler.disable
+def get_downsample_factor():
+    cache_context = get_current_cache_context()
+    assert cache_context is not None, "cache_context must be set before"
+    return cache_context.downsample_factor
+
+@torch.compiler.disable
+def set_first_hidden_states_residual(first_hidden_states_residual):
+    downsample_factor = get_downsample_factor()
+    if downsample_factor > 1:
+        first_hidden_states_residual = first_hidden_states_residual[..., ::downsample_factor]
+        first_hidden_states_residual = first_hidden_states_residual.contiguous()
+    set_buffer("first_hidden_states_residual", first_hidden_states_residual)
+
+
+@torch.compiler.disable
+def get_first_hidden_states_residual():
+    return get_buffer("first_hidden_states_residual")
+
+
+@torch.compiler.disable
+def set_hidden_states_residual(hidden_states_residual):
+    set_buffer("hidden_states_residual", hidden_states_residual)
+
+
+@torch.compiler.disable
+def get_hidden_states_residual():
+    return get_buffer("hidden_states_residual")
+
+
+@torch.compiler.disable
+def set_encoder_hidden_states_residual(encoder_hidden_states_residual):
+    set_buffer("encoder_hidden_states_residual", encoder_hidden_states_residual)
+
+
+@torch.compiler.disable
+def get_encoder_hidden_states_residual():
+    return get_buffer("encoder_hidden_states_residual")
+
+
+class TeaCachedWanTransformerBlocks(torch.nn.Module):
+    def __init__(
+        self,
+        transformer_blocks,
+        single_transformer_blocks=None,
+        *,
+        transformer=None,
+        return_hidden_states_first=True,
+        return_hidden_states_only=False,
+    ):
+        super().__init__()
+        self.transformer = transformer
+        self.transformer_blocks = transformer_blocks
+        self.single_transformer_blocks = single_transformer_blocks
+        self.__class__.accumulated_rel_l1_distance = 0
+        self.__class__.wan_coef = [-3.03318725e+05, 4.90537029e+04, -2.65530556e+03, 5.87365115e+01, -3.15583525e-01]
+        self.__class__.previous_residual = None
+        self.__class__.previous_residual_encoder = None
+        self.__class__.previous_modulated_input = None
+        logger.info("use TeaCache")
+
+    def forward(self, hidden_states, encoder_hidden_states, timestep_proj, *args, **kwargs):
+        if get_current_step() < 5 or get_current_step() >= (get_num_inference_steps() - 1):
+            should_calc = True
+            self.accumulated_rel_l1_distance = 0
+        else:
+            diff = self.l1_distance(self.previous_modulated_input, timestep_proj)
+            result = torch.zeros_like(diff)
+            for i, coef in enumerate(self.wan_coef):
+                result += coef * (diff ** (len(self.wan_coef) - 1 -i))
+            self.accumulated_rel_l1_distance += result
+            if self.accumulated_rel_l1_distance < get_residual_diff_threshold():
+                should_calc = False
+            else:
+                should_calc = True
+                self.accumulated_rel_l1_distance = 0
+        self.previous_modulated_input = timestep_proj
+        mark_step_begin()
+
+        if not should_calc:
+            hidden_states += self.previous_residual
+            encoder_hidden_states += self.previous_residual_encoder
+        else:
+            ori_hidden_states = hidden_states.clone()
+            ori_encoder_hidden_states = encoder_hidden_states.clone()
+            # actual Transformer blocks
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                for i, encoder_block in enumerate(self.transformer_blocks[0:]):
+                    hidden_states = self._gradient_checkpointing_func(
+                        encoder_block, hidden_states, encoder_hidden_states, timestep_proj, *args, **kwargs)
+            else:
+                for i, encoder_block in enumerate(self.transformer_blocks[0:]):
+                    hidden_states = encoder_block(hidden_states, encoder_hidden_states, timestep_proj, *args, **kwargs)
+
+            self.previous_residual = hidden_states - ori_hidden_states
+            self.previous_residual_encoder = encoder_hidden_states - ori_encoder_hidden_states
+
+        return hidden_states
+    @property
+    def is_parallelized(self) -> bool:
+        return get_sequence_parallel_world_size() > 1
+    def all_reduce(self, input_: torch.Tensor, op=torch.distributed.ReduceOp.AVG) -> torch.Tensor:
+        return get_sp_group().all_reduce(input_, op=op) if self.is_parallelized else input_
+    def l1_distance(self, t1: torch.Tensor, t2: torch.Tensor):
+        diff = (t1 - t2).abs().mean()
+        norm = t1.abs().mean()
+        diff, norm = self.all_reduce(diff.unsqueeze(0)), self.all_reduce(norm.unsqueeze(0))
+        return (diff / norm).squeeze()
+
+class FBCachedWanTransformerBlocks(torch.nn.Module):
+    def __init__(
+        self,
+        transformer_blocks,
+        single_transformer_blocks=None,
+        *,
+        transformer=None,
+        return_hidden_states_first=True,
+        return_hidden_states_only=False,
+    ):
+        super().__init__()
+
+        self.transformer = transformer
+        self.transformer_blocks = transformer_blocks
+        self.single_transformer_blocks = single_transformer_blocks
+        self.return_hidden_states_first = return_hidden_states_first
+        self.return_hidden_states_only = return_hidden_states_only
+        logger.info("use FBCache")
+
+    def forward(self, hidden_states, encoder_hidden_states, *args, **kwargs):
+        original_hidden_states = hidden_states
+        first_transformer_block = self.transformer_blocks[0]
+        hidden_states = first_transformer_block(hidden_states, encoder_hidden_states, *args, **kwargs)
+        if not isinstance(hidden_states, torch.Tensor):
+            hidden_states, encoder_hidden_states = hidden_states
+            if not self.return_hidden_states_first:
+                hidden_states, encoder_hidden_states = encoder_hidden_states, hidden_states
+        first_hidden_states_residual = hidden_states - original_hidden_states
+        del original_hidden_states
+        
+        mark_step_begin()
+        #使能位置可调整
+        if get_current_step() < 6 or get_current_step() >= get_num_inference_steps():
+            can_use_cache = False
+        else:
+            can_use_cache = self.get_can_use_cache(
+                first_hidden_states_residual,
+            )
+
+        if can_use_cache:
+            del first_hidden_states_residual
+            hidden_states, encoder_hidden_states = apply_prev_hidden_states_residual(
+                hidden_states, encoder_hidden_states
+            )
+        else:
+            set_first_hidden_states_residual(first_hidden_states_residual)
+            del first_hidden_states_residual
+            (
+                hidden_states,
+                encoder_hidden_states,
+                hidden_states_residual,
+                encoder_hidden_states_residual,
+            ) = self.call_remaining_transformer_blocks(hidden_states, encoder_hidden_states, *args, **kwargs)
+            set_hidden_states_residual(hidden_states_residual)
+            set_encoder_hidden_states_residual(encoder_hidden_states_residual)
+        torch._dynamo.graph_break()
+
+        return (
+            hidden_states
+            if self.return_hidden_states_only
+            else (
+                (hidden_states, encoder_hidden_states)
+                if self.return_hidden_states_first
+                else (encoder_hidden_states, hidden_states)
+            )
+        )
+
+    def call_remaining_transformer_blocks(self, hidden_states, encoder_hidden_states, *args, **kwargs):
+        original_hidden_states = hidden_states
+        original_encoder_hidden_states = encoder_hidden_states
+        for i, encoder_block in enumerate(self.transformer_blocks[1:]):
+            hidden_states = encoder_block(hidden_states, encoder_hidden_states, *args, **kwargs)
+            if not isinstance(hidden_states, torch.Tensor):
+                hidden_states, encoder_hidden_states = hidden_states
+                if not self.return_hidden_states_first:
+                    hidden_states, encoder_hidden_states = encoder_hidden_states, hidden_states
+        if self.single_transformer_blocks is not None:
+            hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
+            for i, block in enumerate(self.single_transformer_blocks):
+                hidden_states = block(hidden_states, *args, **kwargs)
+            encoder_hidden_states, hidden_states = hidden_states.split(
+                [encoder_hidden_states.shape[1], hidden_states.shape[1] - encoder_hidden_states.shape[1]], dim=1
+            )
+
+        # hidden_states_shape = hidden_states.shape
+        # encoder_hidden_states_shape = encoder_hidden_states.shape
+        hidden_states = hidden_states.reshape(-1).contiguous().reshape(original_hidden_states.shape)
+        encoder_hidden_states = (
+            encoder_hidden_states.reshape(-1).contiguous().reshape(original_encoder_hidden_states.shape)
+        )
+
+        # hidden_states = hidden_states.contiguous()
+        # encoder_hidden_states = encoder_hidden_states.contiguous()
+
+        hidden_states_residual = hidden_states - original_hidden_states
+        encoder_hidden_states_residual = encoder_hidden_states - original_encoder_hidden_states
+
+        hidden_states_residual = hidden_states_residual.reshape(-1).contiguous().reshape(original_hidden_states.shape)
+        encoder_hidden_states_residual = (
+            encoder_hidden_states_residual.reshape(-1).contiguous().reshape(original_encoder_hidden_states.shape)
+        )
+
+        return hidden_states, encoder_hidden_states, hidden_states_residual, encoder_hidden_states_residual
+
+    def get_can_use_cache(self, first_hidden_states_residual):
+        if is_in_warmup():
+            return False
+        threshold = get_residual_diff_threshold()
+        if threshold <= 0.0:
+            return False
+        downsample_factor = get_downsample_factor()
+        if downsample_factor > 1:
+            first_hidden_states_residual = first_hidden_states_residual[..., ::downsample_factor]
+        prev_first_hidden_states_residual = get_first_hidden_states_residual()
+        can_use_cache = prev_first_hidden_states_residual is not None and self.are_two_tensors_similar(
+            prev_first_hidden_states_residual,
+            first_hidden_states_residual,
+            threshold=threshold,
+        )
+        return can_use_cache
+
+    @property
+    def is_parallelized(self) -> bool:
+        return get_sequence_parallel_world_size() > 1
+    
+    def all_reduce(self, input_: torch.Tensor, op=torch.distributed.ReduceOp.AVG) -> torch.Tensor:
+        return get_sp_group().all_reduce(input_, op=op) if self.is_parallelized else input_
+    
+    def are_two_tensors_similar(self, t1, t2, *, threshold):
+        if threshold <= 0.0:
+            return False
+        if t1.shape != t2.shape:
+            return False
+    
+        mean_diff = (t1 - t2).abs().mean()
+        mean_t1 = t1.abs().mean()
+        mean_diff, mean_norm = self.all_reduce(mean_diff.unsqueeze(0)), self.all_reduce(mean_t1.unsqueeze(0))
+        diff = (mean_diff / mean_t1).squeeze()
+        return diff < threshold

--- a/xfuser/model_executor/layers/attention_processor.py
+++ b/xfuser/model_executor/layers/attention_processor.py
@@ -427,6 +427,7 @@ class xFuserJointAttnProcessor2_0(JointAttnProcessor2_0):
         **kwargs,
     ) -> torch.FloatTensor:
         residual = hidden_states
+        batch_size = hidden_states.shape[0]
 
         input_ndim = hidden_states.ndim
         if input_ndim == 4:
@@ -434,27 +435,49 @@ class xFuserJointAttnProcessor2_0(JointAttnProcessor2_0):
             hidden_states = hidden_states.view(
                 batch_size, channel, height * width
             ).transpose(1, 2)
-        context_input_ndim = encoder_hidden_states.ndim
-        if context_input_ndim == 4:
-            batch_size, channel, height, width = encoder_hidden_states.shape
-            encoder_hidden_states = encoder_hidden_states.view(
-                batch_size, channel, height * width
-            ).transpose(1, 2)
 
-        batch_size = encoder_hidden_states.shape[0]
+        if encoder_hidden_states is not None:
+            context_input_ndim = encoder_hidden_states.ndim
+            if context_input_ndim == 4:
+                batch_size, channel, height, width = encoder_hidden_states.shape
+                encoder_hidden_states = encoder_hidden_states.view(
+                    batch_size, channel, height * width
+                ).transpose(1, 2)
 
         # `sample` projections.
         query = attn.to_q(hidden_states)
         key = attn.to_k(hidden_states)
         value = attn.to_v(hidden_states)
-
-        # `context` projections.
-        encoder_hidden_states_query_proj = attn.add_q_proj(encoder_hidden_states)
-        encoder_hidden_states_key_proj = attn.add_k_proj(encoder_hidden_states)
-        encoder_hidden_states_value_proj = attn.add_v_proj(encoder_hidden_states)
-
+        
         inner_dim = key.shape[-1]
         head_dim = inner_dim // attn.heads
+
+        # `context` projections.
+        if encoder_hidden_states is not None:
+            encoder_hidden_states_query_proj = attn.add_q_proj(encoder_hidden_states)
+            encoder_hidden_states_key_proj = attn.add_k_proj(encoder_hidden_states)
+            encoder_hidden_states_value_proj = attn.add_v_proj(encoder_hidden_states)
+            encoder_hidden_states_query_proj = (
+                encoder_hidden_states_query_proj.view(
+                    batch_size, -1, attn.heads, head_dim
+                )
+            )
+            encoder_hidden_states_key_proj = encoder_hidden_states_key_proj.view(
+                batch_size, -1, attn.heads, head_dim
+            )
+            encoder_hidden_states_value_proj = (
+                encoder_hidden_states_value_proj.view(
+                    batch_size, -1, attn.heads, head_dim
+                )
+            )
+            if attn.norm_added_q is not None:
+                encoder_hidden_states_query_proj = attn.norm_added_q(encoder_hidden_states_query_proj)
+            if attn.norm_added_k is not None:
+                encoder_hidden_states_key_proj = attn.norm_added_k(encoder_hidden_states_key_proj)
+        else:
+            encoder_hidden_states_query_proj = None
+            encoder_hidden_states_key_proj = None
+            encoder_hidden_states_value_proj = None
 
         #! ---------------------------------------- KV CACHE ----------------------------------------
         if not self.use_long_ctx_attn_kvcache:
@@ -466,33 +489,40 @@ class xFuserJointAttnProcessor2_0(JointAttnProcessor2_0):
             )
         #! ---------------------------------------- KV CACHE ----------------------------------------
 
+        query = query.view(batch_size, -1, attn.heads, head_dim)
+        key = key.view(batch_size, -1, attn.heads, head_dim)
+        value = value.view(batch_size, -1, attn.heads, head_dim)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
         #! ---------------------------------------- ATTENTION ----------------------------------------
         if HAS_LONG_CTX_ATTN and get_sequence_parallel_world_size() > 1:
-            if get_runtime_state().split_text_embed_in_sp:
-                query = torch.cat([query, encoder_hidden_states_query_proj], dim=1)
-                key = torch.cat([key, encoder_hidden_states_key_proj], dim=1)
-                value = torch.cat([value, encoder_hidden_states_value_proj], dim=1)
+            if encoder_hidden_states is not None:
+                if get_runtime_state().split_text_embed_in_sp:
+                    query = torch.cat([query, encoder_hidden_states_query_proj], dim=1)
+                    key = torch.cat([key, encoder_hidden_states_key_proj], dim=1)
+                    value = torch.cat([value, encoder_hidden_states_value_proj], dim=1)
 
-                encoder_hidden_states_query_proj = None
-                encoder_hidden_states_key_proj = None
-                encoder_hidden_states_value_proj = None
-            else:
-                encoder_hidden_states_query_proj = (
-                    encoder_hidden_states_query_proj.view(
+                    encoder_hidden_states_query_proj = None
+                    encoder_hidden_states_key_proj = None
+                    encoder_hidden_states_value_proj = None
+                else:
+                    encoder_hidden_states_query_proj = (
+                        encoder_hidden_states_query_proj.view(
+                            batch_size, -1, attn.heads, head_dim
+                        )
+                    )
+                    encoder_hidden_states_key_proj = encoder_hidden_states_key_proj.view(
                         batch_size, -1, attn.heads, head_dim
                     )
-                )
-                encoder_hidden_states_key_proj = encoder_hidden_states_key_proj.view(
-                    batch_size, -1, attn.heads, head_dim
-                )
-                encoder_hidden_states_value_proj = (
-                    encoder_hidden_states_value_proj.view(
-                        batch_size, -1, attn.heads, head_dim
+                    encoder_hidden_states_value_proj = (
+                        encoder_hidden_states_value_proj.view(
+                            batch_size, -1, attn.heads, head_dim
+                        )
                     )
-                )
-            query = query.view(batch_size, -1, attn.heads, head_dim)
-            key = key.view(batch_size, -1, attn.heads, head_dim)
-            value = value.view(batch_size, -1, attn.heads, head_dim)
 
             hidden_states = self.hybrid_seq_parallel_attn(
                 attn,
@@ -509,9 +539,10 @@ class xFuserJointAttnProcessor2_0(JointAttnProcessor2_0):
             hidden_states = hidden_states.reshape(batch_size, -1, attn.heads * head_dim)
 
         else:
-            query = torch.cat([query, encoder_hidden_states_query_proj], dim=1)
-            key = torch.cat([key, encoder_hidden_states_key_proj], dim=1)
-            value = torch.cat([value, encoder_hidden_states_value_proj], dim=1)
+            if encoder_hidden_states is not None:
+                query = torch.cat([query, encoder_hidden_states_query_proj], dim=1)
+                key = torch.cat([key, encoder_hidden_states_key_proj], dim=1)
+                value = torch.cat([value, encoder_hidden_states_value_proj], dim=1)
 
             if HAS_FLASH_ATTN:
                 from flash_attn import flash_attn_func
@@ -559,28 +590,32 @@ class xFuserJointAttnProcessor2_0(JointAttnProcessor2_0):
         hidden_states = hidden_states.to(query.dtype)
 
         # Split the attention outputs.
-        hidden_states, encoder_hidden_states = (
-            hidden_states[:, : residual.shape[1]],
-            hidden_states[:, residual.shape[1] :],
-        )
+        if encoder_hidden_states is not None:
+            hidden_states, encoder_hidden_states = (
+                hidden_states[:, : residual.shape[1]],
+                hidden_states[:, residual.shape[1] :],
+            )
+            if not attn.context_pre_only:
+                encoder_hidden_states = attn.to_add_out(encoder_hidden_states)
 
         # linear proj
         hidden_states = attn.to_out[0](hidden_states)
         # dropout
         hidden_states = attn.to_out[1](hidden_states)
-        if not attn.context_pre_only:
-            encoder_hidden_states = attn.to_add_out(encoder_hidden_states)
 
         if input_ndim == 4:
             hidden_states = hidden_states.transpose(-1, -2).reshape(
                 batch_size, channel, height, width
             )
-        if context_input_ndim == 4:
-            encoder_hidden_states = encoder_hidden_states.transpose(-1, -2).reshape(
-                batch_size, channel, height, width
-            )
 
-        return hidden_states, encoder_hidden_states
+        if encoder_hidden_states is not None:
+            if context_input_ndim == 4:
+                encoder_hidden_states = encoder_hidden_states.transpose(-1, -2).reshape(
+                    batch_size, channel, height, width
+                )
+            return hidden_states, encoder_hidden_states
+        else:
+            return hidden_states
 
 
 @xFuserAttentionProcessorRegister.register(FluxAttnProcessor2_0)
@@ -1550,3 +1585,117 @@ if HunyuanVideoAttnProcessor2_0 is not None:
 
 else:
     xFuserHunyuanVideoAttnProcessor2_0 = None
+
+from diffusers.models.transformers.transformer_wan import WanAttnProcessor2_0
+@xFuserAttentionProcessorRegister.register(WanAttnProcessor2_0)
+class xFuserWanAttnProcessor2_0(WanAttnProcessor2_0):
+    def __init__(self):
+        super().__init__()
+        from xfuser.core.long_ctx_attention import (
+            xFuserLongContextAttention,
+        )
+        import yunchang
+        from yunchang.kernels import AttnType
+        try:
+            import flash_attn_interface
+            FLASH_ATTN_3_AVAILABLE = True
+        except ModuleNotFoundError:
+            FLASH_ATTN_3_AVAILABLE = False
+
+        if FLASH_ATTN_3_AVAILABLE and self.enable_fa3:
+            self.hybrid_seq_parallel_attn = xFuserLongContextAttention(attn_type=AttnType.FA3)
+        else:
+            self.hybrid_seq_parallel_attn = xFuserLongContextAttention()
+    
+    # NOTE() torch.compile dose not works for V100
+    @torch_compile_disable_if_v100
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        rotary_emb: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        encoder_hidden_states_img = None
+
+        if attn.add_k_proj is not None:
+            # 512 is the context length of the text encoder, hardcoded for now
+            image_context_length = encoder_hidden_states.shape[1] - 512
+            encoder_hidden_states_img = encoder_hidden_states[:, :image_context_length]
+            encoder_hidden_states = encoder_hidden_states[:, image_context_length:]
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+
+        query = attn.to_q(hidden_states)
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        if attn.norm_q is not None:
+            query = attn.norm_q(query)
+        if attn.norm_k is not None:
+            key = attn.norm_k(key)
+
+        query = query.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+        key = key.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+        value = value.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+
+        if rotary_emb is not None:
+            def apply_rotary_emb(
+                hidden_states: torch.Tensor,
+                freqs_cos: torch.Tensor,
+                freqs_sin: torch.Tensor,
+            ):
+                x = hidden_states.view(*hidden_states.shape[:-1], -1, 2)
+                x1, x2 = x[..., 0], x[..., 1]
+                cos = freqs_cos[..., 0::2]
+                sin = freqs_sin[..., 1::2]
+                out = torch.empty_like(hidden_states)
+                out[..., 0::2] = x1 * cos - x2 * sin
+                out[..., 1::2] = x1 * sin + x2 * cos
+                return out.type_as(hidden_states)
+
+            query = apply_rotary_emb(query, *rotary_emb)
+            key = apply_rotary_emb(key, *rotary_emb)
+
+        # I2V task
+        hidden_states_img = None
+        if encoder_hidden_states_img is not None:
+            key_img = attn.add_k_proj(encoder_hidden_states_img)
+            key_img = attn.norm_added_k(key_img)
+            value_img = attn.add_v_proj(encoder_hidden_states_img)
+
+            key_img = key_img.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+            value_img = value_img.unflatten(2, (attn.heads, -1)).transpose(1, 2)
+
+            hidden_states_img = F.scaled_dot_product_attention(
+                query, key_img, value_img, attn_mask=None, dropout_p=0.0, is_causal=False
+            )
+            hidden_states_img = hidden_states_img.transpose(1, 2).flatten(2, 3)
+            hidden_states_img = hidden_states_img.type_as(query)
+
+        #hidden_states = F.scaled_dot_product_attention(
+        #    query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        #)
+        #hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
+        #! ---------------------------------------- ATTENTION ----------------------------------------
+        query = query.transpose(1, 2)  #[2, 40, 2250, 128] bf16
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+        #输入要求(bs, seq_len/N, head_cnt, head_size)
+        hidden_states = self.hybrid_seq_parallel_attn(
+            None,
+            query,
+            key,
+            value,
+            dropout_p=0.0,
+            causal=False,
+        )
+        hidden_states = hidden_states.flatten(2, 3)
+        hidden_states = hidden_states.type_as(query)
+        if hidden_states_img is not None:
+            hidden_states = hidden_states + hidden_states_img
+
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+        return hidden_states

--- a/xfuser/model_executor/models/transformers/__init__.py
+++ b/xfuser/model_executor/models/transformers/__init__.py
@@ -7,7 +7,7 @@ from .latte_transformer_3d import xFuserLatteTransformer3DWrapper
 from .hunyuan_transformer_2d import xFuserHunyuanDiT2DWrapper
 from .cogvideox_transformer_3d import xFuserCogVideoXTransformer3DWrapper
 from .consisid_transformer_3d import xFuserConsisIDTransformer3DWrapper
-
+from .transformer_wan import xFuserWanTransformer3DWrapper
 __all__ = [
     "xFuserTransformerWrappersRegister",
     "xFuserTransformerBaseWrapper",
@@ -17,5 +17,6 @@ __all__ = [
     "xFuserLatteTransformer3DWrapper",
     "xFuserCogVideoXTransformer3DWrapper",
     "xFuserHunyuanDiT2DWrapper",
-    "xFuserConsisIDTransformer3DWrapper"
+    "xFuserConsisIDTransformer3DWrapper",
+    "xFuserWanTransformer3DWrapper"
 ]

--- a/xfuser/model_executor/models/transformers/transformer_wan.py
+++ b/xfuser/model_executor/models/transformers/transformer_wan.py
@@ -1,0 +1,128 @@
+from typing import Optional, Dict, Any, Union, List, Optional, Tuple, Type
+import torch
+import torch.distributed
+import torch.nn as nn
+
+from diffusers.models.transformers import WanTransformer3DModel
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+from diffusers.utils import USE_PEFT_BACKEND, is_torch_version, scale_lora_layers, USE_PEFT_BACKEND, unscale_lora_layers
+
+from xfuser.model_executor.models import xFuserModelBaseWrapper
+from xfuser.logger import init_logger
+from xfuser.model_executor.base_wrapper import xFuserBaseWrapper
+from xfuser.core.distributed import (
+    get_data_parallel_world_size,
+    get_sequence_parallel_world_size,
+    get_pipeline_parallel_world_size,
+    get_classifier_free_guidance_world_size,
+    get_classifier_free_guidance_rank,
+    get_pipeline_parallel_rank,
+    get_pp_group,
+    get_world_group,
+    get_cfg_group,
+    get_sp_group,
+    get_runtime_state,
+    initialize_runtime_state
+)
+
+from xfuser.model_executor.models.transformers.register import xFuserTransformerWrappersRegister
+from xfuser.model_executor.models.transformers.base_transformer import xFuserTransformerBaseWrapper
+
+logger = init_logger(__name__)
+
+
+@xFuserTransformerWrappersRegister.register(WanTransformer3DModel)
+class xFuserWanTransformer3DWrapper(xFuserTransformerBaseWrapper):
+    def __init__(
+        self,
+        transformer: WanTransformer3DModel,
+    ):
+        super().__init__(
+           transformer=transformer,
+           transformer_blocks_name=["blocks"],
+        #    submodule_classes_to_wrap=[nn.Conv2d, CogVideoXPatchEmbed],
+        #    submodule_name_to_wrap=["attn1"]
+        )
+
+
+    @xFuserBaseWrapper.forward_check_condition
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_image: Optional[torch.Tensor] = None,
+        return_dict: bool = True,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
+        if attention_kwargs is not None:
+            attention_kwargs = attention_kwargs.copy()
+            lora_scale = attention_kwargs.pop("scale", 1.0)
+        else:
+            lora_scale = 1.0
+
+        if USE_PEFT_BACKEND:
+            # weight the lora layers by setting `lora_scale` for each PEFT layer
+            scale_lora_layers(self, lora_scale)
+        else:
+            if attention_kwargs is not None and attention_kwargs.get("scale", None) is not None:
+                logger.warning(
+                    "Passing `scale` via `attention_kwargs` when not using the PEFT backend is ineffective."
+                )
+
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.config.patch_size
+        post_patch_num_frames = num_frames // p_t
+        post_patch_height = height // p_h
+        post_patch_width = width // p_w
+
+        rotary_emb = self.rope(hidden_states)
+
+        hidden_states = self.patch_embedding(hidden_states)
+        hidden_states = hidden_states.flatten(2).transpose(1, 2)
+
+        temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image = self.condition_embedder(
+            timestep, encoder_hidden_states, encoder_hidden_states_image
+        )
+        timestep_proj = timestep_proj.unflatten(1, (6, -1))
+
+        if encoder_hidden_states_image is not None:
+            encoder_hidden_states = torch.concat([encoder_hidden_states_image, encoder_hidden_states], dim=1)
+
+        # 4. Transformer blocks
+        if torch.is_grad_enabled() and self.gradient_checkpointing:
+            for block in self.blocks:
+                hidden_states = self._gradient_checkpointing_func(
+                    block, hidden_states, encoder_hidden_states, timestep_proj, rotary_emb
+                )
+        else:
+            for block in self.blocks:
+                hidden_states = block(hidden_states, encoder_hidden_states, timestep_proj, rotary_emb)
+
+        # 5. Output norm, projection & unpatchify
+        shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+
+        # Move the shift and scale tensors to the same device as hidden_states.
+        # When using multi-GPU inference via accelerate these will be on the
+        # first device rather than the last device, which hidden_states ends up
+        # on.
+        shift = shift.to(hidden_states.device)
+        scale = scale.to(hidden_states.device)
+
+        hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(hidden_states)
+        hidden_states = self.proj_out(hidden_states)
+
+        hidden_states = hidden_states.reshape(
+            batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1
+        )
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+        if USE_PEFT_BACKEND:
+            # remove `lora_scale` from each PEFT layer
+            unscale_lora_layers(self, lora_scale)
+
+        if not return_dict:
+            return (output,)
+
+        return Transformer2DModelOutput(sample=output)

--- a/xfuser/model_executor/pipelines/__init__.py
+++ b/xfuser/model_executor/pipelines/__init__.py
@@ -8,7 +8,7 @@ from .pipeline_cogvideox import xFuserCogVideoXPipeline
 from .pipeline_consisid import xFuserConsisIDPipeline
 from .pipeline_hunyuandit import xFuserHunyuanDiTPipeline
 from .pipeline_stable_diffusion_xl import xFuserStableDiffusionXLPipeline
-
+from .pipeline_wan import xFuserWanPipeline
 __all__ = [
     "xFuserPipelineBaseWrapper",
     "xFuserPixArtAlphaPipeline",
@@ -20,4 +20,5 @@ __all__ = [
     "xFuserCogVideoXPipeline",
     "xFuserConsisIDPipeline",
     "xFuserStableDiffusionXLPipeline",
+    "xFuserWanPipeline",
 ]

--- a/xfuser/model_executor/pipelines/pipeline_wan.py
+++ b/xfuser/model_executor/pipelines/pipeline_wan.py
@@ -1,0 +1,304 @@
+import inspect
+import math
+import os
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.distributed
+from diffusers import WanPipeline
+from diffusers.callbacks import MultiPipelineCallbacks, PipelineCallback
+from diffusers.pipelines.wan.pipeline_wan import WanPipelineOutput
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+
+from xfuser.config import EngineConfig
+from xfuser.core.distributed import (
+    get_cfg_group,
+    get_classifier_free_guidance_world_size,
+    get_pipeline_parallel_world_size,
+    get_runtime_state,
+    get_sequence_parallel_rank,
+    get_sequence_parallel_world_size,
+    get_sp_group,
+    is_dp_last_group,
+)
+from xfuser.model_executor.pipelines import xFuserPipelineBaseWrapper
+
+from .register import xFuserPipelineWrapperRegister
+from diffusers.utils import is_torch_xla_available
+
+if is_torch_xla_available():
+    import torch_xla.core.xla_model as xm
+
+    XLA_AVAILABLE = True
+else:
+    XLA_AVAILABLE = False
+
+@xFuserPipelineWrapperRegister.register(WanPipeline)
+class xFuserWanPipeline(xFuserPipelineBaseWrapper):
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
+        engine_config: EngineConfig,
+        **kwargs,
+    ):
+        pipeline = WanPipeline.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        return cls(pipeline, engine_config)
+
+    @property
+    def guidance_scale(self):
+        return self._guidance_scale
+
+    @property
+    def do_classifier_free_guidance(self):
+        return self._guidance_scale > 1.0
+
+    @property
+    def num_timesteps(self):
+        return self._num_timesteps
+
+    @property
+    def current_timestep(self):
+        return self._current_timestep
+
+    @property
+    def interrupt(self):
+        return self._interrupt
+
+    @property
+    def attention_kwargs(self):
+        return self._attention_kwargs
+
+    @torch.no_grad()
+    @xFuserPipelineBaseWrapper.enable_data_parallel
+    @xFuserPipelineBaseWrapper.check_to_use_naive_forward
+    def __call__(
+        self,
+        prompt: Union[str, List[str]] = None,
+        negative_prompt: Union[str, List[str]] = None,
+        height: int = 480,
+        width: int = 832,
+        num_frames: int = 81,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        num_videos_per_prompt: Optional[int] = 1,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.Tensor] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        negative_prompt_embeds: Optional[torch.Tensor] = None,
+        output_type: Optional[str] = "np",
+        return_dict: bool = True,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        callback_on_step_end: Optional[
+            Union[Callable[[int, int, Dict], None], PipelineCallback, MultiPipelineCallbacks]
+        ] = None,
+        callback_on_step_end_tensor_inputs: List[str] = ["latents"],
+        max_sequence_length: int = 512,
+    ):
+        r"""
+        The call function to the pipeline for generation.
+
+        Args:
+            prompt (`str` or `List[str]`, *optional*):
+                The prompt or prompts to guide the image generation. If not defined, one has to pass `prompt_embeds`.
+                instead.
+            height (`int`, defaults to `480`):
+                The height in pixels of the generated image.
+            width (`int`, defaults to `832`):
+                The width in pixels of the generated image.
+            num_frames (`int`, defaults to `81`):
+                The number of frames in the generated video.
+            num_inference_steps (`int`, defaults to `50`):
+                The number of denoising steps. More denoising steps usually lead to a higher quality image at the
+                expense of slower inference.
+            guidance_scale (`float`, defaults to `5.0`):
+                Guidance scale as defined in [Classifier-Free Diffusion
+                Guidance](https://huggingface.co/papers/2207.12598). `guidance_scale` is defined as `w` of equation 2.
+                of [Imagen Paper](https://huggingface.co/papers/2205.11487). Guidance scale is enabled by setting
+                `guidance_scale > 1`. Higher guidance scale encourages to generate images that are closely linked to
+                the text `prompt`, usually at the expense of lower image quality.
+            num_videos_per_prompt (`int`, *optional*, defaults to 1):
+                The number of images to generate per prompt.
+            generator (`torch.Generator` or `List[torch.Generator]`, *optional*):
+                A [`torch.Generator`](https://pytorch.org/docs/stable/generated/torch.Generator.html) to make
+                generation deterministic.
+            latents (`torch.Tensor`, *optional*):
+                Pre-generated noisy latents sampled from a Gaussian distribution, to be used as inputs for image
+                generation. Can be used to tweak the same generation with different prompts. If not provided, a latents
+                tensor is generated by sampling using the supplied random `generator`.
+            prompt_embeds (`torch.Tensor`, *optional*):
+                Pre-generated text embeddings. Can be used to easily tweak text inputs (prompt weighting). If not
+                provided, text embeddings are generated from the `prompt` input argument.
+            output_type (`str`, *optional*, defaults to `"np"`):
+                The output format of the generated image. Choose between `PIL.Image` or `np.array`.
+            return_dict (`bool`, *optional*, defaults to `True`):
+                Whether or not to return a [`WanPipelineOutput`] instead of a plain tuple.
+            attention_kwargs (`dict`, *optional*):
+                A kwargs dictionary that if specified is passed along to the `AttentionProcessor` as defined under
+                `self.processor` in
+                [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
+            callback_on_step_end (`Callable`, `PipelineCallback`, `MultiPipelineCallbacks`, *optional*):
+                A function or a subclass of `PipelineCallback` or `MultiPipelineCallbacks` that is called at the end of
+                each denoising step during the inference. with the following arguments: `callback_on_step_end(self:
+                DiffusionPipeline, step: int, timestep: int, callback_kwargs: Dict)`. `callback_kwargs` will include a
+                list of all tensors as specified by `callback_on_step_end_tensor_inputs`.
+            callback_on_step_end_tensor_inputs (`List`, *optional*):
+                The list of tensor inputs for the `callback_on_step_end` function. The tensors specified in the list
+                will be passed as `callback_kwargs` argument. You will only be able to include variables listed in the
+                `._callback_tensor_inputs` attribute of your pipeline class.
+            autocast_dtype (`torch.dtype`, *optional*, defaults to `torch.bfloat16`):
+                The dtype to use for the torch.amp.autocast.
+
+        Examples:
+
+        Returns:
+            [`~WanPipelineOutput`] or `tuple`:
+                If `return_dict` is `True`, [`WanPipelineOutput`] is returned, otherwise a `tuple` is returned where
+                the first element is a list with the generated images and the second element is a list of `bool`s
+                indicating whether the corresponding generated image contains "not-safe-for-work" (nsfw) content.
+        """
+        if isinstance(callback_on_step_end, (PipelineCallback, MultiPipelineCallbacks)):
+            callback_on_step_end_tensor_inputs = callback_on_step_end.tensor_inputs
+
+        # 1. Check inputs. Raise error if not correct
+        self.check_inputs(
+            prompt,
+            negative_prompt,
+            height,
+            width,
+            prompt_embeds,
+            negative_prompt_embeds,
+            callback_on_step_end_tensor_inputs,
+        )
+
+        if num_frames % self.vae_scale_factor_temporal != 1:
+            logger.warning(
+                f"`num_frames - 1` has to be divisible by {self.vae_scale_factor_temporal}. Rounding to the nearest number."
+            )
+            num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
+        num_frames = max(num_frames, 1)
+
+        self._guidance_scale = guidance_scale
+        self._attention_kwargs = attention_kwargs
+        self._current_timestep = None
+        self._interrupt = False
+
+        device = self._execution_device
+
+        # 2. Define call parameters
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        # 3. Encode input prompt
+        prompt_embeds, negative_prompt_embeds = self.encode_prompt(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            do_classifier_free_guidance=self.do_classifier_free_guidance,
+            num_videos_per_prompt=num_videos_per_prompt,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            max_sequence_length=max_sequence_length,
+            device=device,
+        )
+
+        transformer_dtype = self.transformer.dtype
+        prompt_embeds = prompt_embeds.to(transformer_dtype)
+        if negative_prompt_embeds is not None:
+            negative_prompt_embeds = negative_prompt_embeds.to(transformer_dtype)
+
+        if self.do_classifier_free_guidance:
+            prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+        # 4. Prepare timesteps
+        self.scheduler.set_timesteps(num_inference_steps, device=device)
+        timesteps = self.scheduler.timesteps
+
+        # 5. Prepare latent variables
+        num_channels_latents = self.transformer.config.in_channels
+        latents = self.prepare_latents(
+            batch_size * num_videos_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            num_frames,
+            torch.float32,
+            device,
+            generator,
+            latents,
+        )
+
+        # 6. Denoising loop
+        num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
+        self._num_timesteps = len(timesteps)
+
+        with self.progress_bar(total=num_inference_steps) as progress_bar:
+            for i, t in enumerate(timesteps):
+                if self.interrupt:
+                    continue
+
+                self._current_timestep = t
+
+                latent_model_input = latents.to(transformer_dtype)
+                latent_model_input = torch.cat([latent_model_input] * 2) if self.do_classifier_free_guidance else latents
+                timestep = t.expand(latent_model_input.shape[0])
+
+                # predict noise model_output
+                noise_pred = self.transformer(
+                    hidden_states=latent_model_input,
+                    timestep=timestep,
+                    encoder_hidden_states=prompt_embeds,
+                    attention_kwargs=attention_kwargs,
+                    return_dict=False,
+                )[0]
+
+                if self.do_classifier_free_guidance:
+                    noise_pred_uncond, noise_pred_text = noise_pred.chunk(2)
+                    noise_pred = noise_pred_uncond + self.guidance_scale * (noise_pred_text - noise_pred_uncond)
+                # compute the previous noisy sample x_t -> x_t-1
+                latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+
+                if callback_on_step_end is not None:
+                    callback_kwargs = {}
+                    for k in callback_on_step_end_tensor_inputs:
+                        callback_kwargs[k] = locals()[k]
+                    callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
+
+                    latents = callback_outputs.pop("latents", latents)
+                    prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
+                    negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
+
+                # call the callback, if provided
+                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                    progress_bar.update()
+
+                if XLA_AVAILABLE:
+                    xm.mark_step()
+
+        self._current_timestep = None
+
+        if not output_type == "latent":
+            latents = latents.to(self.vae.dtype)
+            latents_mean = (
+                torch.tensor(self.vae.config.latents_mean)
+                .view(1, self.vae.config.z_dim, 1, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+                latents.device, latents.dtype
+            )
+            latents = latents / latents_std + latents_mean
+            video = self.vae.decode(latents, return_dict=False)[0]
+            video = self.video_processor.postprocess_video(video, output_type=output_type)
+        else:
+            video = latents
+
+        # Offload all models
+        self.maybe_free_model_hooks()
+
+        if not return_dict:
+            return (video,)
+
+        return WanPipelineOutput(frames=video)


### PR DESCRIPTION
性能测试方法
```
cd /app/xDiT && \
torchrun --nproc_per_node=8 ./examples/wan2_cfg_usp_example.py --model /data00/models/Wan2.1-T2V-14B-Diffusers/  --height 720 --width 1280 --num_frames 81 --seed 0  --num_inference_steps 50 --warmup_steps 0 --prompt 'Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage.' --negative_prompt "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人 很多，倒着走"  --use_cfg_parallel  --ulysses_degree 4 --ring_degree 1  --enable_fa3 --use_torch_compile --use_fbcache --cache_threshold 0.16
```