### PR TITLE
Add SageAttention support for Wan2.1

### DIFF
--- a/examples/run_wan2_cfg_usp.sh
+++ b/examples/run_wan2_cfg_usp.sh
@@ -11,7 +11,7 @@ INFERENCE_STEP=50
 mkdir -p ./results
 
 # Wan2.1 specific task args
-TASK_ARGS="--height 720 --width 1280 --num_frames 81 --seed 0 --enable_fa3 --use_torch_compile --use_fbcache --cache_threshold 0.16"
+TASK_ARGS="--height 720 --width 1280 --num_frames 81 --seed 0 --enable_sage_attn --use_torch_compile --use_fbcache --cache_threshold 0.16"
 N_GPUS=8
 PARALLEL_ARGS="--ulysses_degree 4 --ring_degree 1"
 CFG_ARGS="--use_cfg_parallel"

--- a/examples/wan2_cfg_usp_example.py
+++ b/examples/wan2_cfg_usp_example.py
@@ -175,6 +175,11 @@ def main():
     engine_args = xFuserArgs.from_cli_args(args)
     engine_config, input_config = engine_args.create_config()
     
+    if args.enable_sage_attn:
+        setattr(xFuserWanAttnProcessor2_0, "enable_sage_attn", True)
+    else:
+        setattr(xFuserWanAttnProcessor2_0, "enable_sage_attn", False)
+
     if args.enable_fa3:
         assert torch.cuda.get_device_capability()[0] >= 9, (
             "FlashAttention v3 requires SM >= 90. "

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -106,6 +106,7 @@ class xFuserArgs:
     enable_tiling: bool = False
     enable_slicing: bool = False
     enable_fa3: bool = False
+    enable_sage_attn: bool = False
     # DiTFastAttn arguments
     use_fast_attn: bool = False
     n_calib: int = 8
@@ -333,6 +334,12 @@ class xFuserArgs:
             action="store_true",
             help="Enable FlashAttention 3.",
         )
+        runtime_group.add_argument(
+            "--enable-sage-attn",
+            "--enable_sage_attn",
+            action="store_true",
+            help="Whether use sageattention for the attention layer.",
+        )
 
         # DiTFastAttn arguments
         fast_attn_group = parser.add_argument_group("DiTFastAttn Options")
@@ -456,6 +463,7 @@ class xFuserArgs:
             parallel_config=parallel_config,
             fast_attn_config=fast_attn_config,
             enable_fa3=self.enable_fa3,
+            enable_sage_attn=self.enable_sage_attn,
         )
 
         input_config = InputConfig(

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -241,6 +241,7 @@ class EngineConfig:
     parallel_config: ParallelConfig
     fast_attn_config: FastAttnConfig
     enable_fa3: bool = False
+    enable_sage_attn: bool = False
 
     def __post_init__(self):
         if self.fast_attn_config.use_fast_attn:

--- a/xfuser/model_executor/layers/attention_processor.py
+++ b/xfuser/model_executor/layers/attention_processor.py
@@ -45,6 +45,18 @@ if torch.__version__ >= "2.5.0":
 else:
     from xfuser.model_executor.layers.usp_legacy import USP
 
+try:
+    import flash_attn_interface
+    FLASH_ATTN_3_AVAILABLE = True
+except ModuleNotFoundError:
+    FLASH_ATTN_3_AVAILABLE = False
+
+try:
+    import sageattention
+    SAGE_ATTENTION_AVAILABLE = True
+except ModuleNotFoundError:
+    SAGE_ATTENTION_AVAILABLE = False
+
 logger = init_logger(__name__)
 
 env_info = PACKAGES_CHECKER.get_packages_info()
@@ -1596,13 +1608,10 @@ class xFuserWanAttnProcessor2_0(WanAttnProcessor2_0):
         )
         import yunchang
         from yunchang.kernels import AttnType
-        try:
-            import flash_attn_interface
-            FLASH_ATTN_3_AVAILABLE = True
-        except ModuleNotFoundError:
-            FLASH_ATTN_3_AVAILABLE = False
 
-        if FLASH_ATTN_3_AVAILABLE and self.enable_fa3:
+        if SAGE_ATTENTION_AVAILABLE and self.enable_sage_attn:
+            self.hybrid_seq_parallel_attn = xFuserLongContextAttention(attn_type=AttnType.SAGE_AUTO)
+        elif FLASH_ATTN_3_AVAILABLE and self.enable_fa3:
             self.hybrid_seq_parallel_attn = xFuserLongContextAttention(attn_type=AttnType.FA3)
         else:
             self.hybrid_seq_parallel_attn = xFuserLongContextAttention()


### PR DESCRIPTION
This PR add SageAttention support for Wan2.1. Use sageattention is very easy through new option '--enable-sage-attn' or '--enable_sage_attn'.

### Prerequisite
Install SageAttention from source.
```bash
git clone https://github.com/thu-ml/SageAttention.git && \
	cd SageAttention && \
	python3 setup.py install
```

### Benchmark
The benchmark run with FBCache enabled and torch.compile enabled.

| GPU | Model | Resolution | epoch time(s) | boost |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| 8*H20 | Wan2.1-T2V-14B-Diffusers | 1280 * 720 | 284.53 (baseline) | - |
| 8*H20 | Wan2.1-T2V-14B-Diffusers | 1280 * 720 | 210.76 (enable-fa3) | +25.9% |
| 8*H20 | Wan2.1-T2V-14B-Diffusers | 1280 * 720 | 147.90 (enable-sage-attn)|  +48.0%  |

