### PR TITLE
add SVDQuant support for FLUX family models

### DIFF
--- a/docker/Dockerfile.bd_iaas
+++ b/docker/Dockerfile.bd_iaas
@@ -59,6 +59,10 @@ RUN git clone https://github.com/bytedance-iaas/SageAttention.git && \
 	git checkout ${SAGE_ATTN_BRANCH} && \
 	python3 setup.py install
 
+RUN git clone https://github.com/mit-han-lab/nunchaku.git --recursive && \
+	cd nunchaku && \
+	python setup.py develop
+
 # Copy the entire comfyui-xdit directory into the container
 # COPY ./http-service /app/http-service
 RUN mkdir /app && \

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -53,6 +53,9 @@ PARALLEL_ARGS="--pipefusion_parallel_degree 2 --ulysses_degree 2 --ring_degree 2
 # Use this flag to quantize the T5 text encoder, which could reduce the memory usage and have no effect on the result quality.
 # QUANTIZE_FLAG="--use_fp8_t5_encoder"
 
+# SVDQuant flag
+SVDQ_FLAG="--use_svdq --svdq_quantized_model_path /path/to/nunchaku-flux.1-dev/svdq-int4_r32-flux.1-dev.safetensors"
+
 # export CUDA_VISIBLE_DEVICES=4,5,6,7
 
 torchrun --nproc_per_node=$N_GPUS ./examples/$SCRIPT \
@@ -69,3 +72,4 @@ $PARALLLEL_VAE \
 $COMPILE_FLAG \
 $QUANTIZE_FLAG \
 $CACHE_ARGS \
+$SVDQ_FLAG

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -118,6 +118,8 @@ class xFuserArgs:
     use_fbcache: bool = False
     cache_threshold : float = 0.12
     use_fp8_t5_encoder: bool = False
+    use_svdq: bool = False
+    svdq_quantized_model_path: str = ""
 
     @staticmethod
     def add_cli_args(parser: FlexibleArgumentParser):
@@ -340,6 +342,17 @@ class xFuserArgs:
             action="store_true",
             help="Whether use sageattention for the attention layer.",
         )
+        runtime_group.add_argument(
+            "--use_svdq",
+            "--use-svdq",
+            action="store_true",
+            help="Whether use SVDQuant or not.",
+        )
+        runtime_group.add_argument(
+            "--svdq-quantized-model-path",
+            "--svdq_quantized_model_path",
+            help="Path to SVDQuant quantized model."
+        )
 
         # DiTFastAttn arguments
         fast_attn_group = parser.add_argument_group("DiTFastAttn Options")
@@ -464,6 +477,8 @@ class xFuserArgs:
             fast_attn_config=fast_attn_config,
             enable_fa3=self.enable_fa3,
             enable_sage_attn=self.enable_sage_attn,
+            use_svdq=self.use_svdq,
+            svdq_quantized_model_path=self.svdq_quantized_model_path,
         )
 
         input_config = InputConfig(

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -242,6 +242,8 @@ class EngineConfig:
     fast_attn_config: FastAttnConfig
     enable_fa3: bool = False
     enable_sage_attn: bool = False
+    use_svdq: bool = False
+    svdq_quantized_model_path: str = ""
 
     def __post_init__(self):
         if self.fast_attn_config.use_fast_attn:

--- a/xfuser/model_executor/pipelines/pipeline_flux.py
+++ b/xfuser/model_executor/pipelines/pipeline_flux.py
@@ -61,7 +61,21 @@ class xFuserFluxPipeline(xFuserPipelineBaseWrapper):
         return_org_pipeline: bool = False,
         **kwargs,
     ):
-        pipeline = FluxPipeline.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        if engine_config.use_svdq:
+            from nunchaku import NunchakuFluxTransformer2dModel
+
+            transformer = NunchakuFluxTransformer2dModel.from_pretrained(
+                engine_config.svdq_quantized_model_path
+            )
+            transformer.set_attention_impl("nunchaku-fp16")
+
+            pipeline = FluxPipeline.from_pretrained(pretrained_model_name_or_path, transformer=transformer, **kwargs)
+            if "use_fbcache" in cache_args and cache_args["use_fbcache"]:
+                from nunchaku.caching.diffusers_adapters import apply_cache_on_pipe
+                apply_cache_on_pipe(pipeline, residual_diff_threshold=cache_args["rel_l1_thresh"])
+        else:
+            pipeline = FluxPipeline.from_pretrained(pretrained_model_name_or_path, **kwargs)
+
         if return_org_pipeline:
             return pipeline
         return cls(pipeline, engine_config, cache_args)


### PR DESCRIPTION
This PR add SVDQuant for FLUX family models, like FLUX.1-dev, FLUX.1-schnell.

## Prerequsite
* Install nunchaku following https://github.com/mit-han-lab/nunchaku 
* Download quantized model `mit-han-lab/nunchaku-flux.1-dev` and `mit-han-lab/nunchaku-flux.1-schnell` from huggingface.

## How to use
We provide two options `--use_svdq` and `--svdq_quantized_model_path` to enable SVDQuant.

Fox example, run FLUX.1-dev inference on single L20.
```bash
torchrun --nproc_per_node=1 ./examples/flux_example.py --model /data00/models/FLUX.1-dev/ --height 1024 --width 1024 --no_use_resolution_binning --num_inference_steps 28 --warmup_steps 1 --prompt 'brown dog laying on the ground with a metal bowl in front of him.' --use_fbcache --use_svdq --svdq_quantized_model_path /data00/models/nunchaku-flux.1-dev/svdq-int4_r32-flux.1-dev.safetensors
```
## Benchmark
The benchmark run with use_torch_compile enabled and FBCache enabled.
| GPU | Model | Resolution | epoch time(s) | boost |
| ----------- | ----------- | ----------- | ----------- | ----------- |
| 1*L20 | FLUX.1-dev | 1024 * 1024 | 9.91 (baseline) | - |
| 1*L20 | FLUX.1-dev | 1024 * 1024 | 4.76 (--use_svdq) | +51.9% |

 



